### PR TITLE
Disable propagation of opinions of IE users

### DIFF
--- a/content.js
+++ b/content.js
@@ -48,8 +48,6 @@ function fireEvent(element,event) {
        evt.preventDefault();
        return !element.dispatchEvent(evt);
    } else {
-       // dispatch for IE
-       var evt = document.createEventObject();
-       return element.fireEvent('on'+event,evt)
+       alert("Sorry, we do not want to propagate the opinions of IE users.");
    }
 }


### PR DESCRIPTION
If people are using internet explorer, we should avoid submitting their Likes to Facebook so as not to bias the algorithms that depend on those likes.
